### PR TITLE
tweak api url to avoid errors in the api stats web

### DIFF
--- a/src/rain-alert.coffee
+++ b/src/rain-alert.coffee
@@ -37,7 +37,7 @@ module.exports = (robot) ->
       robot.messageRoom(room, message)
 
   checkForRain = ->
-    http.get("http://api.wunderground.com/api/" + token + "/features/conditions/q/" + station + ".json", (res) ->
+    http.get("http://api.wunderground.com/api/" + token + "/conditions/q/" + station + ".json", (res) ->
       dataString = ""
       res.on 'data', (data) ->
         dataString += data.toString()


### PR DESCRIPTION
Hi, first thanks for this great script @jaxbot. 
I'm seeing errors like this in the api web stats site:
`unknownfeature	9	2017-01-22	1	1	/api/xxxxxxxxxxxxxx/features/conditions/q/whatever.json`

Seems like they remove that prefix and you just call the feature by name. But for luck the script still works, this change it's just to avoid those unharmful errors.

Thanks, salud!.